### PR TITLE
Change notation for YAML keywords

### DIFF
--- a/config/uspto-applications-0105.yaml
+++ b/config/uspto-applications-0105.yaml
@@ -1,8 +1,8 @@
 patent-application-publication:
-  entity: application
-  pk: subdoc-bibliographic-information/document-id/doc-number
-  filename_field: source_file
-  fields:
+  <entity>: application
+  <primary_key>: subdoc-bibliographic-information/document-id/doc-number
+  <filename_field>: source_file
+  <fields>:
     # Bibliographic info
     subdoc-bibliographic-information/document-id/doc-number: doc_number
     subdoc-bibliographic-information/document-id/kind_code: kind_code
@@ -15,8 +15,8 @@ patent-application-publication:
 
     # Assignee information
     subdoc-bibliographic-information/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         organization-name: org_name
         assignee-type: role
         name/given-name: given_name
@@ -47,24 +47,24 @@ patent-application-publication:
     subdoc-bibliographic-information/technical-information/classification-ipc/classification-ipc-edition: IPC_edition
     subdoc-bibliographic-information/technical-information/classification-ipc/classification-ipc-primary/ipc: IPC_main
     subdoc-bibliographic-information/technical-information/classification-ipc/classification-ipc-secondary/ipc:
-      fieldname: IPC_further
-      joiner: "|"
+      <fieldname>: IPC_further
+      <joiner>: "|"
 
     subdoc-bibliographic-information/international-conventions/pct-application/document-id/doc-number: PCT_app_number
 
     # Claims
     subdoc-claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
 
     # Provisional applications techincally aren't "parents"
     subdoc-bibliographic-information/continuity-data/non-provisional-of-provisional:
-      entity: provisional_application
-      fields:
+      <entity>: provisional_application
+      <fields>:
         document-id/doc-number: doc_number
         document-id/document-date: date
 
@@ -75,14 +75,14 @@ patent-application-publication:
 
     ### Continuations
     subdoc-bibliographic-information/continuity-data/continuations/continuation-of/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -94,14 +94,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/continuations/continuation-in-part-of/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -111,14 +111,14 @@ patent-application-publication:
         parent-status: status
 
     subdoc-bibliographic-information/continuity-data/continuations/continuing-reissue-of/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -131,14 +131,14 @@ patent-application-publication:
     ### Non-Continuations
 
     subdoc-bibliographic-information/continuity-data/division-of/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -149,14 +149,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/a-371-of-international/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: a_371_of_international
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: a_371_of_international
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -167,14 +167,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/substitution-for/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -185,14 +185,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/reissue-of/parent-child/parent:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -205,14 +205,14 @@ patent-application-publication:
     ## Child documents
     ### Continuations
     subdoc-bibliographic-information/continuity-data/continuations/continuation-of/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -222,14 +222,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/continuations/continuation-in-part-of/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -238,14 +238,14 @@ patent-application-publication:
         document-id/country-code: country_code
 
     subdoc-bibliographic-information/continuity-data/continuations/continuing-reissue-of/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -257,14 +257,14 @@ patent-application-publication:
     ### Non-Continuations
 
     subdoc-bibliographic-information/continuity-data/division-of/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -274,14 +274,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/a-371-of-international/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: a_371_of_international
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: a_371_of_international
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -291,14 +291,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/substitution-for/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -308,14 +308,14 @@ patent-application-publication:
 
 
     subdoc-bibliographic-information/continuity-data/reissue-of/parent-child/child:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from record to record
         document-id/kind-code: kind_code
@@ -326,8 +326,8 @@ patent-application-publication:
 
     # Inventors
     subdoc-bibliographic-information/inventors/first-named-inventor:
-      entity: inventor
-      fields:
+      <entity>: inventor
+      <fields>:
 
         name/family-name: last_name
         name/given-name: given_name
@@ -344,8 +344,8 @@ patent-application-publication:
         authority-applicant: authority_applicant
 
     subdoc-bibliographic-information/inventors/inventor:
-      entity: inventor
-      fields:
+      <entity>: inventor
+      <fields>:
 
         name/family-name: last_name
         name/given-name: given_name
@@ -363,8 +363,8 @@ patent-application-publication:
 
     # Foreign filings
     subdoc-bibliographic-information/foreign-priority-data:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         priority-application-number/doc-number: doc_number
         filing-date: date
         country-code: country_code

--- a/config/uspto-applications-0506.yaml
+++ b/config/uspto-applications-0506.yaml
@@ -1,9 +1,9 @@
 us-patent-application:
-  entity: application
-  pk: us-bibliographic-data-application/publication-reference/document-id/doc-number
-  filename_field: source_file
+  <entity>: application
+  <primary_key>: us-bibliographic-data-application/publication-reference/document-id/doc-number
+  <filename_field>: source_file
 
-  fields:
+  <fields>:
     us-bibliographic-data-application/publication-reference/document-id/doc-number: doc_number
     us-bibliographic-data-application/publication-reference/document-id/kind: kind_code
     us-bibliographic-data-application/publication-reference/document-id/country: country_code
@@ -15,11 +15,11 @@ us-patent-application:
 
     # Claims
     claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     # Correspondence Address
     us-bibliographic-data-application/parties/correspondence-address/addressbook/address/city: correspondence_city
@@ -36,23 +36,23 @@ us-patent-application:
     us-bibliographic-data-application/classification-ipc/edition: IPC_edition
     us-bibliographic-data-application/classification-ipc/main-classification: IPC_main
     us-bibliographic-data-application/classification-ipc/further-classification:
-      fieldname: IPC_further
-      joiner: "|"
+      <fieldname>: IPC_further
+      <joiner>: "|"
 
 
 
     # Foreign filings
     us-bibliographic-data-application/priority-claims/priority-claim:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         doc-number: doc_number
         date: date
         country: country_code
 
     # Applicants
     us-bibliographic-data-application/parties/applicants/applicant:
-      entity: inventor
-      fields:
+      <entity>: inventor
+      <fields>:
         # Name information
         addressbook/name/last-name: last_name
         addressbook/name/first-name: given_name
@@ -64,8 +64,8 @@ us-patent-application:
 
     # Assignees
     us-bibliographic-data-application/assignees/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         addressbook/orgname: org_name
         addressbook/role: role
         addressbook/first-name: given_name
@@ -85,14 +85,14 @@ us-patent-application:
     ### Continuations
 
     us-bibliographic-data-application/us-related-documents/continuation/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -102,14 +102,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/continuation-in-part/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -119,14 +119,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/continuing-reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -139,14 +139,14 @@ us-patent-application:
     ### Non-Continuations
 
     us-bibliographic-data-application/us-related-documents/addition/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -156,14 +156,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/division/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -173,14 +173,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -190,14 +190,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/reexamination/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -207,14 +207,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/us-reexamination-reissue-merger/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: us_reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: us_reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -224,14 +224,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/substitution/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -241,14 +241,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/utility-model-basis/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -262,14 +262,14 @@ us-patent-application:
     ### Continuations
 
     us-bibliographic-data-application/us-related-documents/continuation/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -278,14 +278,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/continuation-in-part/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -294,14 +294,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/continuing-reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -313,14 +313,14 @@ us-patent-application:
     ### Non-Continuations
 
     us-bibliographic-data-application/us-related-documents/addition/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -329,14 +329,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/division/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -345,14 +345,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -361,14 +361,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/reexamination/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -377,14 +377,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/us-reexamination-reissue-merger/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: us_reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: us_reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -393,14 +393,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/substitution/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -409,14 +409,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/utility-model-basis/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number

--- a/config/uspto-applications-0613.yaml
+++ b/config/uspto-applications-0613.yaml
@@ -1,9 +1,9 @@
 us-patent-application:
-  entity: application
-  pk: us-bibliographic-data-application/publication-reference/document-id/doc-number
-  filename_field: source_file
+  <entity>: application
+  <primary_key>: us-bibliographic-data-application/publication-reference/document-id/doc-number
+  <filename_field>: source_file
 
-  fields:
+  <fields>:
     us-bibliographic-data-application/publication-reference/document-id/doc-number: doc_number
     us-bibliographic-data-application/publication-reference/document-id/kind: kind_code
     us-bibliographic-data-application/publication-reference/document-id/country: country_code
@@ -15,11 +15,11 @@ us-patent-application:
 
     # Claims
     claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     # Correspondence Address
     us-bibliographic-data-application/parties/correspondence-address/addressbook/address/city: correspondence_city
@@ -33,43 +33,43 @@ us-patent-application:
     # Classification Information
     # USPC
     us-bibliographic-data-application/classification-national/main-classification: USPC_class
-    us-bibliographic-data-application/classification-national/further-classification: 
-        fieldname: USPC_subclass
-        joiner: "|"
+    us-bibliographic-data-application/classification-national/further-classification:
+        <fieldname>: USPC_subclass
+        <joiner>: "|"
 
     ## IPC
-    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/ipc-version-indicator/date: 
-        fieldname: IPC_edition
-        joiner: "|"
-    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/section: 
-        fieldname: IPC_section
-        joiner: "|"
-    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/class: 
-        fieldname: IPC_class
-        joiner: "|"
-    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/subclass: 
-        fieldname: IPC_subclass
-        joiner: "|"
-    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/main-group: 
-        fieldname: IPC_main_group
-        joiner: "|"
+    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/ipc-version-indicator/date:
+        <fieldname>: IPC_edition
+        <joiner>: "|"
+    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/section:
+        <fieldname>: IPC_section
+        <joiner>: "|"
+    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/class:
+        <fieldname>: IPC_class
+        <joiner>: "|"
+    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/subclass:
+        <fieldname>: IPC_subclass
+        <joiner>: "|"
+    us-bibliographic-data-application/classifications-ipcr/classification-ipcr/main-group:
+        <fieldname>: IPC_main_group
+        <joiner>: "|"
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/subgroup:
-        fieldname: IPC_subgroup
-        joiner: "|"
+        <fieldname>: IPC_subgroup
+        <joiner>: "|"
 
 
     # Foreign filings
     us-bibliographic-data-application/priority-claims/priority-claim:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         doc-number: doc_number
         date: date
         country: country_code
 
     # Applicants
     us-bibliographic-data-application/parties/applicants/applicant:
-      entity: inventor
-      fields:
+      <entity>: inventor
+      <fields>:
         # Name information
         addressbook/last-name: last_name
         addressbook/first-name: given_name
@@ -82,8 +82,8 @@ us-patent-application:
 
     # Assignees
     us-bibliographic-data-application/assignees/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         addressbook/orgname: org_name
         addressbook/role: role
         addressbook/first-name: given_name
@@ -103,14 +103,14 @@ us-patent-application:
     ### Continuations
 
     us-bibliographic-data-application/us-related-documents/continuation/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -120,14 +120,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/continuation-in-part/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -137,14 +137,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/continuing-reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -157,14 +157,14 @@ us-patent-application:
     ### Non-Continuations
 
     us-bibliographic-data-application/us-related-documents/addition/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -174,14 +174,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/division/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -191,14 +191,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -208,14 +208,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/reexamination/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -225,14 +225,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/us-reexamination-reissue-merger/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: us_reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: us_reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -242,14 +242,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/substitution/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -259,14 +259,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/utility-model-basis/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -280,14 +280,14 @@ us-patent-application:
     ### Continuations
 
     us-bibliographic-data-application/us-related-documents/continuation/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -296,14 +296,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/continuation-in-part/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -312,14 +312,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/continuing-reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -331,14 +331,14 @@ us-patent-application:
     ### Non-Continuations
 
     us-bibliographic-data-application/us-related-documents/addition/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -347,14 +347,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/division/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -363,14 +363,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -379,14 +379,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/reexamination/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -395,14 +395,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/us-reexamination-reissue-merger/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: us_reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: us_reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -411,14 +411,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/substitution/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -427,14 +427,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/utility-model-basis/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number

--- a/config/uspto-applications-13+.yaml
+++ b/config/uspto-applications-13+.yaml
@@ -1,9 +1,9 @@
 us-patent-application:
-  entity: application
-  pk: us-bibliographic-data-application/publication-reference/document-id/doc-number
-  filename_field: source_file
+  <entity>: application
+  <primary_key>: us-bibliographic-data-application/publication-reference/document-id/doc-number
+  <filename_field>: source_file
 
-  fields:
+  <fields>:
     us-bibliographic-data-application/publication-reference/document-id/doc-number: doc_number
     us-bibliographic-data-application/publication-reference/document-id/kind: kind_code
     us-bibliographic-data-application/publication-reference/document-id/country: country_code
@@ -15,16 +15,16 @@ us-patent-application:
 
     us-bibliographic-data-application/invention-title: title
     description/p:
-      fieldname: fullDes
-      joiner: "\n"
+      <fieldname>: fullDes
+      <joiner>: "\n"
 
     # Claims
     claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     # Correspondence Address
     us-bibliographic-data-application/us-parties/agents/agent/addressbook/address/city: correspondence_city
@@ -47,36 +47,36 @@ us-patent-application:
 
     ## IPC
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/ipc-version-indicator/date:
-        fieldname: IPC_edition
-        joiner: "|"
+        <fieldname>: IPC_edition
+        <joiner>: "|"
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/section:
-        fieldname: IPC_section
-        joiner: "|"
+        <fieldname>: IPC_section
+        <joiner>: "|"
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/class:
-        fieldname: IPC_class
-        joiner: "|"
+        <fieldname>: IPC_class
+        <joiner>: "|"
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/subclass:
-        fieldname: IPC_subclass
-        joiner: "|"
+        <fieldname>: IPC_subclass
+        <joiner>: "|"
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/main-group:
-        fieldname: IPC_main_group
-        joiner: "|"
+        <fieldname>: IPC_main_group
+        <joiner>: "|"
     us-bibliographic-data-application/classifications-ipcr/classification-ipcr/subgroup:
-        fieldname: IPC_subgroup
-        joiner: "|"
+        <fieldname>: IPC_subgroup
+        <joiner>: "|"
 
     # Foreign filings
     us-bibliographic-data-application/priority-claims/priority-claim:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         doc-number: doc_number
         date: date
         country: country_code
 
     # Inventors
     us-bibliographic-data-application/parties/applicants/applicant:
-      - entity: inventor
-        fields:
+      - <entity>: inventor
+        <fields>:
           # Name information
           addressbook/last-name: last_name
           addressbook/first-name: given_name
@@ -86,8 +86,8 @@ us-patent-application:
           addressbook/address/state: res_state
           addressbook/address/city: res_city
 
-      - entity: applicant
-        fields:
+      - <entity>: applicant
+        <fields>:
           # Name information
           addressbook/last-name: last_name
           addressbook/first-name: given_name
@@ -100,8 +100,8 @@ us-patent-application:
     # Applicants
     ## Domestic applicants
     us-bibliographic-data-application/us-parties/us-applicants/us-applicant:
-      entity: applicant
-      fields:
+      <entity>: applicant
+      <fields>:
         # Name information
         addressbook/last-name: last_name
         addressbook/first-name: given_name
@@ -116,8 +116,8 @@ us-patent-application:
 
     # Assignees
     us-bibliographic-data-application/assignees/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         orgname: org_name
         addressbook/orgname: org_name
 
@@ -146,14 +146,14 @@ us-patent-application:
     ### Continuations
 
     us-bibliographic-data-application/us-related-documents/continuation/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -163,14 +163,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/continuation-in-part/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -180,14 +180,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/continuing-reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -200,14 +200,14 @@ us-patent-application:
     ### Non-Continuations
 
     us-bibliographic-data-application/us-related-documents/addition/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -217,14 +217,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/division/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -234,14 +234,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -251,14 +251,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/reexamination/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -268,14 +268,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/us-reexamination-reissue-merger/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: us_reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: us_reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -285,14 +285,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/substitution/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -302,14 +302,14 @@ us-patent-application:
         parent-status: status
 
     us-bibliographic-data-application/us-related-documents/utility-model-basis/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: parent
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -323,14 +323,14 @@ us-patent-application:
     ### Continuations
 
     us-bibliographic-data-application/us-related-documents/continuation/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -339,14 +339,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/continuation-in-part/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -355,14 +355,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/continuing-reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -374,14 +374,14 @@ us-patent-application:
     ### Non-Continuations
 
     us-bibliographic-data-application/us-related-documents/addition/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -390,14 +390,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/division/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -406,14 +406,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -422,14 +422,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/reexamination/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -438,14 +438,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/us-reexamination-reissue-merger/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: us_reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: us_reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -454,14 +454,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/substitution/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number
@@ -470,14 +470,14 @@ us-patent-application:
         document-id/country: country_code
 
     us-bibliographic-data-application/us-related-documents/utility-model-basis/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         # These values are fixed for all related documents found at this location
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: child
 
         # These vary from document to document
         document-id/doc-number: doc_number

--- a/config/uspto-grants-0105.yaml
+++ b/config/uspto-grants-0105.yaml
@@ -1,41 +1,41 @@
 PATDOC:
   # entity is used for the name of the table and for fieldnames for foreign key
   #  relations with related entities.
-  entity: patent
-  
+  <entity>: patent
+
   # pk is optional -- if supplied, text extracted from the supplied path will be
   #  used for the primary ket of the table (so it must be unique!).  If this key
   #  is not supplied, an auto-incremented integer will be used for the pk.
-  pk: SDOBI/B200/B210/DNUM
-  
+  <primary_key>: SDOBI/B200/B210/DNUM
+
   # filename_field is optional -- if supplied, the name of the file containing
   #  the XML parsed to make this record will be saved to a field named for the
   #  value supplied.
-  filename_field: source_file
+  <filename_field>: source_file
 
-  fields:
+  <fields>:
     SDOBI/B500/B570/B577: num_claims
     SDOBI/B500/B540/STEXT: title
 
     SDOCL/CL/CLM:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         # the asterisk specifies that all sub-elements of each PATDOC/SDOCL/CL/CLM
         #  will be reduced to their text content, and the results of each such
         #  reduction (for each PATDOC/SDOCL/CL/CLM element, should there be more
         #  than one) will be concatenated together with the `joiner` string -- in
         #  this case, a newline.
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     SDOBI/B100/B110/DNUM: doc_number
     SDOBI/B100/B130: kind_code
     SDOBI/B100/B190: country_code
 
     SDOBI/B300:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         B310/DNUM: doc_number
         B320/DATE: date
         B330/CTRY: country_code
@@ -44,20 +44,20 @@ PATDOC:
     SDOBI/B100/B140/DATE: doc_date
     SDOBI/B500/B510/B511: IPC_primary
     SDOBI/B500/B510/B512:
-      fieldname: IPC_secondary
-      joiner: "|"
+      <fieldname>: IPC_secondary
+      <joiner>: "|"
 
     SDOBI/B500/B520/B521: USPC_primary
     SDOBI/B500/B520/B522:
-      fieldname: USPC_secondary
-      joiner: "|"
+      <fieldname>: USPC_secondary
+      <joiner>: "|"
     SDOBI/B500/B520/B522US: USPC_secondary
 
     SDOBI/B500/B510/B516: IPC_edition
 
     SDOBI/B700/B720/B721:
-      entity: applicant
-      fields:
+      <entity>: applicant
+      <fields>:
         PARTY-US/NAM/SNM/STEXT: last_name
         PARTY-US/NAM/FNM: given_name
         PARTY-US/NAM/ONM/STEXT: org_name
@@ -68,14 +68,14 @@ PATDOC:
     SDOBI/B200/B211US: series_code
 
     SDOBI/B700/B730:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         B731/PARTY-US/NAM/ONM/STEXT: org_name
         B732US: role
 
     SDOBI/B500/B560/B561:
-      entity: citation
-      fields:
+      <entity>: citation
+      <fields>:
         PCIT/DOC/DNUM: doc_number
         PCIT/DOC/KIND: kind_code
         PCIT/DOC/CTRY: country_code
@@ -88,22 +88,22 @@ PATDOC:
         #  multiple paths are found that reference the same fieldname, as here,
         #  the value that comes last in order in the config file will prevail.
         CITED-BY-EXAMINER:
-          fieldname: cited_by
-          enum_type: examiner
+          <fieldname>: cited_by
+          <enum_type>: examiner
         CITED-BY-OTHER:
-          fieldname: cited_by
-          enum_type: other
+          <fieldname>: cited_by
+          <enum_type>: other
         PCIT/PNC: cited_in
 
     SDOBI/B500/B560/B562:
-      entity: citation
-      fields:
+      <entity>: citation
+      <fields>:
         CITED-BY-EXAMINER:
-          fieldname: cited_by
-          enum_type: examiner
+          <fieldname>: cited_by
+          <enum_type>: examiner
         CITED-BY-OTHER:
-          fieldname: cited_by
-          enum_type: other
+          <fieldname>: cited_by
+          <enum_type>: other
         NCIT/STEXT: cited_in_other
 
     SDOBI/B700/B745/B746/PARTY-US/NAM/SNM/STEXT: examiner1_last_name
@@ -116,104 +116,104 @@ PATDOC:
 
     ## Parent Documents
     SDOBI/B600/B610/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B620/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B630/B631/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B630/B632/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B630/B633/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B640/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B641US/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B645/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
@@ -222,51 +222,51 @@ PATDOC:
     # TODO: This is wrong, but I literally can't find one in the data
     # TODO: and this way we at least get to see them in the data
     SDOBI/B600/B645US:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         PDAT:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
           - "*":
-              fieldname: doc_number
-              joiner: "|#|"
+              <fieldname>: doc_number
+              <joiner>: "|#|"
 
     SDOBI/B600/B650:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B660/PARENT-US/PDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: subsitute
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: subsitute
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B680US:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: provisional_application
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: provisional_application
+          - <fieldname>: relationship
+            <enum_type>: parent
         DOC/DNUM: doc_number
         DOC/DATE: date
 
@@ -274,117 +274,117 @@ PATDOC:
 
     ## Child Documents
     SDOBI/B600/B610/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B620/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: division
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: division
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B630/B631/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B630/B632/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B630/B633/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B640/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B641US/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B645/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
         DOC/CTRY: country_code
 
     SDOBI/B600/B660/PARENT-US/CDOC:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         DOC:
-          - fieldname: type
-            enum_type: subsitute
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: subsitute
+          - <fieldname>: relationship
+            <enum_type>: child
         DOC/DNUM: doc_number
         DOC/DATE: date
         DOC/KIND: kind_code
@@ -392,4 +392,4 @@ PATDOC:
 
     #Saves the name of the file where the patent was retreived
     #Note this is not present in the XML; special handling by parser
-    filename_field: source_file
+    <filename_field>: source_file

--- a/config/uspto-grants-0506.yaml
+++ b/config/uspto-grants-0506.yaml
@@ -1,21 +1,21 @@
 us-patent-grant:
-  entity: patent
-  pk: us-bibliographic-data-grant/application-reference/document-id/doc-number
-  filename_field: source_file
-  fields:
+  <entity>: patent
+  <primary_key>: us-bibliographic-data-grant/application-reference/document-id/doc-number
+  <filename_field>: source_file
+  <fields>:
     us-bibliographic-data-grant/number-of-claims: num_claims
 
     claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         # the asterisk specifies that all sub-elements of each us-patent-grant/claims/claim
         #  will be reduced to their text content, and the results of each such
         #  reduction (for each us-patent-grant/claims/claim element, should there be more
         #  than one) will be concatenated together with the `joiner` string -- in
         #  this case, a newline.
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     us-bibliographic-data-grant/invention-title: title
 
@@ -24,8 +24,8 @@ us-patent-grant:
     us-bibliographic-data-grant/publication-reference/document-id/country: country_code
 
     us-bibliographic-data-grant/priority-claims/priority-claim:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         doc-number: doc_number
         country: country_code
         date: date
@@ -36,8 +36,8 @@ us-patent-grant:
 
     us-bibliographic-data-grant/classification-ipc/main-classification: IPC_primary
     us-bibliographic-data-grant/classification-ipc/further-classification:
-      fieldname: IPC_secondary
-      joiner: "|"
+      <fieldname>: IPC_secondary
+      <joiner>: "|"
     us-bibliographic-data-grant/classification-ipc/edition: IPC_edition
 
 
@@ -45,13 +45,13 @@ us-patent-grant:
     us-bibliographic-data-grant/classification-national/edition : USPC_edition
     us-bibliographic-data-grant/classification-national/main-classification : USPC_primary
     us-bibliographic-data-grant/classification-national/further-classification :
-      fieldname: USPC_secondary
-      joiner: "|"
+      <fieldname>: USPC_secondary
+      <joiner>: "|"
 
 
     us-bibliographic-data-grant/parties/applicants/applicant/addressbook:
-      entity: applicant
-      fields:
+      <entity>: applicant
+      <fields>:
         last-name: last_name
         first-name: given_name
         orgname: org_name
@@ -64,22 +64,22 @@ us-patent-grant:
     us-bibliographic-data-grant/application-reference/@appl-type: filing_type
 
     us-bibliographic-data-grant/assignees/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         addressbook/orgname: org_name
         addressbook/role: role
 
     us-bibliographic-data-grant/references-cited/citation:
-      entity: citation
-      fields:
+      <entity>: citation
+      <fields>:
         patcit/document-id/country: country_code
         patcit/document-id/doc-number: doc_number
         patcit/document-id/kind: kind_code
         patcit/document-id/name: name
         patcit/document-id/date: date
         category:
-          fieldname: cited_by
-          enum_map:
+          <fieldname>: cited_by
+          <enum_map>:
             cited by examiner: examiner
             cited by other: other
         classification-national/country: class_country
@@ -96,158 +96,158 @@ us-patent-grant:
     # Related Documents
     ## Parent Applications
     us-bibliographic-data-grant/us-related-documents/addition/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/division/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation-in-part/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuing-reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-divisional-reissue/us-relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reexamination/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-reexamination-reissue-merger/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/substitution/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-provisional-application:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: us_provisional_application
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: us_provisional_application
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
         us-provisional-application-status: status
 
     us-bibliographic-data-grant/us-related-documents/utility-model-basis/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/related-publication/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
@@ -255,153 +255,153 @@ us-patent-grant:
 
     ##Child documents
     us-bibliographic-data-grant/us-related-documents/addition/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/division/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation-in-part/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuing-reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-divisional-reissue/us-relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reexamination/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-reexamination-reissue-merger/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/substitution/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/utility-model-basis/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/related-publication/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
 
   us-bibliographic-data-grant/us-related-documents/correction:
-    entity: correction
-    fields:
+    <entity>: correction
+    <fields>:
       document-corrected/document-id/doc-number: corrected_doc
       type-of-correction: correction_type
       gazette-reference: gazette_reference
@@ -409,4 +409,4 @@ us-patent-grant:
 
     #Saves the name of the file where the patent was retreived
     #Note this is not present in the XML; special handling by parser
-    filename_field: source_file
+    <filename_field>: source_file

--- a/config/uspto-grants-0613.yaml
+++ b/config/uspto-grants-0613.yaml
@@ -1,21 +1,21 @@
 us-patent-grant:
-  entity: patent
-  pk: us-bibliographic-data-grant/application-reference/document-id/doc-number
-  filename_field: source_file
-  fields:
+  <entity>: patent
+  <primary_key>: us-bibliographic-data-grant/application-reference/document-id/doc-number
+  <filename_field>: source_file
+  <fields>:
     us-bibliographic-data-grant/number-of-claims: num_claims
 
     claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         # the asterisk specifies that all sub-elements of each us-patent-grant/claims/claim
         #  will be reduced to their text content, and the results of each such
         #  reduction (for each us-patent-grant/claims/claim element, should there be more
         #  than one) will be concatenated together with the `joiner` string -- in
         #  this case, a newline.
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     us-bibliographic-data-grant/invention-title: title
 
@@ -24,8 +24,8 @@ us-patent-grant:
     us-bibliographic-data-grant/publication-reference/document-id/country: country_code
 
     us-bibliographic-data-grant/priority-claims/priority-claim:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         doc-number: doc_number
         country: country_code
         date: date
@@ -34,37 +34,37 @@ us-patent-grant:
     us-bibliographic-data-grant/publication-reference/document-id/date: doc_date
 
 
-    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/section: 
-        fieldname: IPC_section
-        joiner: "|"
-    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/class: 
-        fieldname: IPC_class
-        joiner: "|"
-    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/subclass: 
-        fieldname: IPC_subclass
-        joiner: "|"
-    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/main-group: 
-        fieldname: IPC_main_group
-        joiner: "|"
-    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/subgroup: 
-        fieldname: IPC_subgroup
-        joiner: "|"
-    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/ipc-version-indicator/date: 
-        fieldname: IPC_edition
-        joiner: "|"
+    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/section:
+        <fieldname>: IPC_section
+        <joiner>: "|"
+    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/class:
+        <fieldname>: IPC_class
+        <joiner>: "|"
+    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/subclass:
+        <fieldname>: IPC_subclass
+        <joiner>: "|"
+    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/main-group:
+        <fieldname>: IPC_main_group
+        <joiner>: "|"
+    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/subgroup:
+        <fieldname>: IPC_subgroup
+        <joiner>: "|"
+    us-bibliographic-data-grant/classifications-ipcr/classification-ipcr/ipc-version-indicator/date:
+        <fieldname>: IPC_edition
+        <joiner>: "|"
 
 
     us-bibliographic-data-grant/classification-national/country : USPC_country
     us-bibliographic-data-grant/classification-national/edition : USPC_edition
     us-bibliographic-data-grant/classification-national/main-classification : USPC_primary
     us-bibliographic-data-grant/classification-national/further-classification :
-      fieldname: USPC_secondary
-      joiner: "|"
+      <fieldname>: USPC_secondary
+      <joiner>: "|"
 
 
     us-bibliographic-data-grant/parties/applicants/applicant/addressbook:
-      entity: applicant
-      fields:
+      <entity>: applicant
+      <fields>:
         last-name: last_name
         first-name: given_name
         orgname: org_name
@@ -78,22 +78,22 @@ us-patent-grant:
     us-bibliographic-data-grant/application-reference/@appl-type: filing_type
 
     us-bibliographic-data-grant/assignees/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         addressbook/orgname: org_name
         addressbook/role: role
 
     us-bibliographic-data-grant/references-cited/citation:
-      entity: citation
-      fields:
+      <entity>: citation
+      <fields>:
         patcit/document-id/country: country_code
         patcit/document-id/doc-number: doc_number
         patcit/document-id/kind: kind_code
         patcit/document-id/name: name
         patcit/document-id/date: date
         category:
-          fieldname: cited_by
-          enum_map:
+          <fieldname>: cited_by
+          <enum_map>:
             cited by examiner: examiner
             cited by other: other
         classification-national/country: class_country
@@ -110,158 +110,158 @@ us-patent-grant:
     # Related Documents
     ## Parent Applications
     us-bibliographic-data-grant/us-related-documents/addition/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/division/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation-in-part/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuing-reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-divisional-reissue/us-relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reexamination/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-reexamination-reissue-merger/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/substitution/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-provisional-application:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: us_provisional_application
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: us_provisional_application
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
         us-provisional-application-status: status
 
     us-bibliographic-data-grant/us-related-documents/utility-model-basis/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/related-publication/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
@@ -269,152 +269,152 @@ us-patent-grant:
 
     ##Child documents
     us-bibliographic-data-grant/us-related-documents/addition/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/division/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation-in-part/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuing-reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-divisional-reissue/us-relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reexamination/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-reexamination-reissue-merger/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/substitution/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/utility-model-basis/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/related-publication/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/correction:
-      entity: correction
-      fields:
+      <entity>: correction
+      <fields>:
         document-corrected/document-id/doc-number: corrected_doc
         type-of-correction: correction_type
         gazette-reference: gazette_reference

--- a/config/uspto-grants-13+.yaml
+++ b/config/uspto-grants-13+.yaml
@@ -1,21 +1,21 @@
 us-patent-grant:
-  entity: patent
-  pk: us-bibliographic-data-grant/application-reference/document-id/doc-number
-  filename_field: source_file
-  fields:
+  <entity>: patent
+  <primary_key>: us-bibliographic-data-grant/application-reference/document-id/doc-number
+  <filename_field>: source_file
+  <fields>:
     us-bibliographic-data-grant/number-of-claims: num_claims
 
     claims/claim:
-      entity: claim
-      fields:
+      <entity>: claim
+      <fields>:
         # the asterisk specifies that all sub-elements of each us-patent-grant/claims/claim
         #  will be reduced to their text content, and the results of each such
         #  reduction (for each us-patent-grant/claims/claim element, should there be more
         #  than one) will be concatenated together with the `joiner` string -- in
         #  this case, a newline.
         "*":
-          fieldname: claim_text
-          joiner: "\n"
+          <fieldname>: claim_text
+          <joiner>: "\n"
 
     us-bibliographic-data-grant/invention-title: title
 
@@ -24,8 +24,8 @@ us-patent-grant:
     us-bibliographic-data-grant/publication-reference/document-id/country: country_code
 
     us-bibliographic-data-grant/priority-claims/priority-claim:
-      entity: foreign_filing
-      fields:
+      <entity>: foreign_filing
+      <fields>:
         doc-number: doc_number
         country: country_code
         date: date
@@ -36,8 +36,8 @@ us-patent-grant:
 
     us-bibliographic-data-grant/classification-ipc/main-classification: IPC_primary
     us-bibliographic-data-grant/classification-ipc/further-classification:
-      fieldname: IPC_secondary
-      joiner: "|"
+      <fieldname>: IPC_secondary
+      <joiner>: "|"
     us-bibliographic-data-grant/classification-ipc/edition: IPC_edition
 
 
@@ -46,8 +46,8 @@ us-patent-grant:
     us-bibliographic-data-grant/classification-national/edition : USPC_edition
     us-bibliographic-data-grant/classification-national/main-classification : USPC_primary
     us-bibliographic-data-grant/classification-national/further-classification :
-      fieldname: USPC_secondary
-      joiner: "|"
+      <fieldname>: USPC_secondary
+      <joiner>: "|"
 
     us-bibliographic-data-grant/classifications-cpc/main-cpc/classification-cpc/cpc-version-indicator/date: CPC_edition
     us-bibliographic-data-grant/classifications-cpc/main-cpc/classification-cpc/section: CPC_section
@@ -58,8 +58,8 @@ us-patent-grant:
 
 
     us-bibliographic-data-grant/us-parties/us-applicants/us-applicant/addressbook:
-      entity: applicant
-      fields:
+      <entity>: applicant
+      <fields>:
         last-name: last_name
         first-name: given_name
         orgname: org_name
@@ -67,8 +67,8 @@ us-patent-grant:
         address/country: res_country
 
     us-bibliographic-data-grant/us-parties/inventors/inventor/addressbook:
-      entity: inventor
-      fields:
+      <entity>: inventor
+      <fields>:
         last-name: last_name
         first-name: given_name
         orgname: org_name
@@ -82,22 +82,22 @@ us-patent-grant:
     us-bibliographic-data-grant/application-reference/@appl-type: filing_type
 
     us-bibliographic-data-grant/assignees/assignee:
-      entity: assignee
-      fields:
+      <entity>: assignee
+      <fields>:
         addressbook/orgname: org_name
         addressbook/role: role
 
     us-bibliographic-data-grant/us-references-cited/us-citation:
-      entity: citation
-      fields:
+      <entity>: citation
+      <fields>:
         patcit/document-id/country: country_code
         patcit/document-id/doc-number: doc_number
         patcit/document-id/kind: kind_code
         patcit/document-id/name: name
         patcit/document-id/date: date
         category:
-          fieldname: cited_by
-          enum_map:
+          <fieldname>: cited_by
+          <enum_map>:
             cited by examiner: examiner
             cited by other: other
         classification-national/country: class_country
@@ -114,158 +114,158 @@ us-patent-grant:
     # Related Documents
     ## Parent Applications
     us-bibliographic-data-grant/us-related-documents/addition/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/division/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation-in-part/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuing-reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reissue/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-divisional-reissue/us-relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reexamination/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-reexamination-reissue-merger/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/substitution/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-provisional-application:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: us_provisional_application
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: us_provisional_application
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
         us-provisional-application-status: status
 
     us-bibliographic-data-grant/us-related-documents/utility-model-basis/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/related-publication/relation/parent-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: parent
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: parent
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
@@ -273,152 +273,152 @@ us-patent-grant:
 
     ##Child documents
     us-bibliographic-data-grant/us-related-documents/addition/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: addition
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: addition
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/division/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuation-in-part/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuation_in_part
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuation_in_part
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/continuing-reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: continuing_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: continuing_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reissue/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-divisional-reissue/us-relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: divisional_reissue
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: divisional_reissue
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/reexamination/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/us-reexamination-reissue-merger/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: reexamination_reissue_merger
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: reexamination_reissue_merger
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/substitution/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: substitution
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: substitution
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/utility-model-basis/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: utility_model_basis
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: utility_model_basis
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/related-publication/relation/child-doc:
-      entity: related_document
-      fields:
+      <entity>: related_document
+      <fields>:
         document-id:
-          - fieldname: type
-            enum_type: related_publication
-          - fieldname: relationship
-            enum_type: child
+          - <fieldname>: type
+            <enum_type>: related_publication
+          - <fieldname>: relationship
+            <enum_type>: child
         document-id/country: country_code
         document-id/doc-number: doc_number
         document-id/date: date
 
     us-bibliographic-data-grant/us-related-documents/correction:
-      entity: correction
-      fields:
+      <entity>: correction
+      <fields>:
         document-corrected/document-id/doc-number: corrected_doc
         type-of-correction: correction_type
         gazette-reference: gazette_reference

--- a/patent_xml_to_csv.py
+++ b/patent_xml_to_csv.py
@@ -141,8 +141,8 @@ class PatentXmlToTabular:
         ).strip()
 
     def get_pk(self, tree, config):
-        if "pk" in config:
-            elems = tree.findall("./" + config["pk"])
+        if "<primary_key>" in config:
+            elems = tree.findall("./" + config["<primary_key>"])
             assert len(elems) == 1
             return self.get_text(elems[0])
         return None
@@ -153,7 +153,7 @@ class PatentXmlToTabular:
         """ Process a subtree of the xml as a new entity type, creating a new record in a new
             output table/file.
         """
-        entity = config["entity"]
+        entity = config["<entity>"]
         for elem in elems:
             record = {}
 
@@ -166,9 +166,9 @@ class PatentXmlToTabular:
 
             if parent_pk:
                 record[f"{parent_entity}_id"] = parent_pk
-            if "filename_field" in config:
-                record[config["filename_field"]] = self.current_filename
-            for subpath, subconfig in config["fields"].items():
+            if "<filename_field>" in config:
+                record[config["<filename_field>"]] = self.current_filename
+            for subpath, subconfig in config["<fields>"].items():
                 self.process_path(elem, subpath, subconfig, record, entity, pk)
 
             self.tables[entity].append(record)
@@ -198,35 +198,35 @@ class PatentXmlToTabular:
                 self.add_string(path, elems, record, config)
             return
 
-        if "entity" in config:
+        if "<entity>" in config:
             # config is a new entity definition (i.e. a new record on a new table/file)
             self.process_new_entity(tree, elems, config, parent_entity, parent_pk)
             return
 
-        if "fieldname" in config:
+        if "<fieldname>" in config:
             # config is extra configuration for a field on this table/file
-            if "joiner" in config:
+            if "<joiner>" in config:
                 if elems:
-                    record[config["fieldname"]] = config["joiner"].join(
+                    record[config["<fieldname>"]] = config["<joiner>"].join(
                         [self.get_text(elem) for elem in elems]
                     )
                 return
 
-            if "enum_map" in config:
+            if "<enum_map>" in config:
                 if elems:
-                    record[config["fieldname"]] = config["enum_map"].get(
+                    record[config["<fieldname>"]] = config["<enum_map>"].get(
                         self.get_text(elems[0])
                     )
                 return
 
-            if "enum_type" in config:
+            if "<enum_type>" in config:
                 if elems:
-                    record[config["fieldname"]] = config["enum_type"]
+                    record[config["<fieldname>"]] = config["<enum_type>"]
                 return
 
             # just a mapping to a fieldname string
             if len(config) == 1:
-                self.add_string(path, elems, record, config["fieldname"])
+                self.add_string(path, elems, record, config["<fieldname>"])
                 return
 
         # We may have multiple configurations for this key (XPath expression)
@@ -343,23 +343,23 @@ class PatentXmlToTabular:
                 _fieldnames.append(config)
                 return
 
-            if "fieldname" in config:
-                _fieldnames.append(config["fieldname"])
+            if "<fieldname>" in config:
+                _fieldnames.append(config["<fieldname>"])
                 return
 
-            if "entity" in config:
-                entity = config["entity"]
+            if "<entity>" in config:
+                entity = config["<entity>"]
                 _fieldnames = []
-                if "pk" in config or parent_entity:
+                if "<primary_key>" in config or parent_entity:
                     _fieldnames.append("id")
                 if parent_entity:
                     _fieldnames.append(f"{parent_entity}_id")
-                if "filename_field" in config:
-                    _fieldnames.append(config["filename_field"])
-                for subconfig in config["fields"].values():
+                if "<filename_field>" in config:
+                    _fieldnames.append(config["<filename_field>"])
+                for subconfig in config["<fields>"].values():
                     add_fieldnames(subconfig, _fieldnames, entity)
-                # different keys (XPath expressions) may be appending rows to the same table(s),
-                #  so we're appending to lists of fieldnames here.
+                # different keys (XPath expressions) may be appending rows to the same
+                #  table(s), so we're appending to lists of fieldnames here.
                 fieldnames[entity] = list(
                     dict.fromkeys(fieldnames[entity] + _fieldnames).keys()
                 )


### PR DESCRIPTION
This PR updates the config files to wrap keywords in `<`angle brackets`>` to distinguish them from the XPath expressions that serve as keys to the input XML files.