### PR TITLE
Wrong PKs in grant config?

### DIFF
--- a/config/uspto-grants.2002-2004.yaml
+++ b/config/uspto-grants.2002-2004.yaml
@@ -6,7 +6,7 @@ PATDOC:
   # pk is optional -- if supplied, text extracted from the supplied path will be
   #  used for the primary ket of the table (so it must be unique!).  If this key
   #  is not supplied, an auto-incremented integer will be used for the pk.
-  <primary_key>: SDOBI/B200/B210/DNUM
+  <primary_key>: SDOBI/B100/B110/DNUM
 
   # filename_field is optional -- if supplied, the name of the file containing
   #  the XML parsed to make this record will be saved to a field named for the

--- a/config/uspto-grants.2005.yaml
+++ b/config/uspto-grants.2005.yaml
@@ -1,6 +1,6 @@
 us-patent-grant:
   <entity>: patent
-  <primary_key>: us-bibliographic-data-grant/application-reference/document-id/doc-number
+  <primary_key>: us-bibliographic-data-grant/publication-reference/document-id/doc-number
   <filename_field>: source_file
   <fields>:
     us-bibliographic-data-grant/number-of-claims: num_claims

--- a/config/uspto-grants.2006-20130108.yaml
+++ b/config/uspto-grants.2006-20130108.yaml
@@ -1,6 +1,6 @@
 us-patent-grant:
   <entity>: patent
-  <primary_key>: us-bibliographic-data-grant/application-reference/document-id/doc-number
+  <primary_key>: us-bibliographic-data-grant/publication-reference/document-id/doc-number
   <filename_field>: source_file
   <fields>:
     us-bibliographic-data-grant/number-of-claims: num_claims

--- a/config/uspto-grants.20130105+.yaml
+++ b/config/uspto-grants.20130105+.yaml
@@ -1,6 +1,6 @@
 us-patent-grant:
   <entity>: patent
-  <primary_key>: us-bibliographic-data-grant/application-reference/document-id/doc-number
+  <primary_key>: us-bibliographic-data-grant/publication-reference/document-id/doc-number
   <filename_field>: source_file
   <fields>:
     us-bibliographic-data-grant/number-of-claims: num_claims


### PR DESCRIPTION
I've just completed a full run of all the grants documents from 2002-2019.  It spat out a sqlite file which is 53.8Gb (without indexes of any kind -- basic PK and FK constraints add ~20% to the file size) and contains a total of 288,841,106 records in 8 tables, for a total of 4,616,172 document processed.

In doing some basic analysis to check all's well, however, I seem to have found a problem.  In all the config files pertaining to grants, the primary key for the `patent` table is sourced from the `application-reference` section of the XML record (`SDOBI/B200/` for the pre-2005 files).  Unfortunately, it seems that this value does not uniquely identify a grant document, as multiple documents may reference the same application.  Rather, I think, the primary key should be taken from the `publication-reference` (`SDOBI/B100/` for the pre-2005 files), as effected by this PR.

@gmoore016 -- could you take a look at this please and give me your opinion?
